### PR TITLE
Open "enough folds" in preview

### DIFF
--- a/lua/trouble/view.lua
+++ b/lua/trouble/view.lua
@@ -306,7 +306,8 @@ function View:preview()
         vim.api.nvim_set_current_win(self.parent)
 
         vim.cmd("buffer " .. item.bufnr)
-        vim.cmd("norm! zz")
+        -- Center preview line on screen and open enough folds to show it
+        vim.cmd("norm! zz zv")
         vim.api.nvim_set_current_win(self.win)
         vim.api.nvim_set_current_buf(self.buf)
 


### PR DESCRIPTION
Currently trouble preview centers the screen on line in question. If that line is inside fold, it is not really helpful as nothing is actually shown.

This PR adds "opening enough folds" with `zv` alongside with centering the screen. Another cool thing would be to restore folds to previous state after finishing preview, but this is not really a trivial task.