### PR TITLE
Implement 'default_fold' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Trouble comes with the following defaults:
     auto_open = false, -- automatically open the list when you have diagnostics
     auto_close = false, -- automatically close the list when you have no diagnostics
     auto_preview = true, -- automatically preview the location of the diagnostic. <esc> to close preview and go back
-    default_fold = "open", -- default fold state of a file trouble list at creation (either "open" or "close")
+    auto_fold = false, -- automatically fold a file trouble list at creation
     signs = {
         -- icons / text used for a diagnostic
         error = "",

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Trouble comes with the following defaults:
     auto_open = false, -- automatically open the list when you have diagnostics
     auto_close = false, -- automatically close the list when you have no diagnostics
     auto_preview = true, -- automatically preview the location of the diagnostic. <esc> to close preview and go back
+    default_fold = "open", -- default fold state of a file trouble list at creation (either "open" or "close")
     signs = {
         -- icons / text used for a diagnostic
         error = "",

--- a/doc/lsp-trouble.txt
+++ b/doc/lsp-trouble.txt
@@ -104,6 +104,7 @@ Trouble comes with the following defaults:
         auto_open = false, -- automatically open the list when you have diagnostics    
         auto_close = false, -- automatically close the list when you have no diagnostics    
         auto_preview = true, -- automatically preview the location of the diagnostic. <esc> to close preview and go back    
+        default_fold = "open", -- default fold state of a file troube list at creation (either "open" or "close")
         signs = {    
             -- icons / text used for a diagnostic    
             error = "",    

--- a/doc/lsp-trouble.txt
+++ b/doc/lsp-trouble.txt
@@ -104,7 +104,7 @@ Trouble comes with the following defaults:
         auto_open = false, -- automatically open the list when you have diagnostics    
         auto_close = false, -- automatically close the list when you have no diagnostics    
         auto_preview = true, -- automatically preview the location of the diagnostic. <esc> to close preview and go back    
-        default_fold = "open", -- default fold state of a file troube list at creation (either "open" or "close")
+        auto_fold = false, -- automatically fold a file trouble list at creation
         signs = {    
             -- icons / text used for a diagnostic    
             error = "",    

--- a/lua/trouble/config.lua
+++ b/lua/trouble/config.lua
@@ -26,7 +26,7 @@ local defaults = {
     auto_open = false, -- automatically open the list when you have diagnostics
     auto_close = false, -- automatically close the list when you have no diagnostics
     auto_preview = true, -- automatyically preview the location of the diagnostic. <esc> to close preview and go back to last window
-    default_fold = "open", -- default fold state of a file trouble list at creation (either "open" or "close")
+    auto_fold = false, -- automatically fold a file trouble list at creation
     signs = {
         -- icons / text used for a diagnostic
         error = "",

--- a/lua/trouble/config.lua
+++ b/lua/trouble/config.lua
@@ -26,6 +26,7 @@ local defaults = {
     auto_open = false, -- automatically open the list when you have diagnostics
     auto_close = false, -- automatically close the list when you have no diagnostics
     auto_preview = true, -- automatyically preview the location of the diagnostic. <esc> to close preview and go back to last window
+    default_fold = "open", -- default fold state of a file trouble list at creation (either "open" or "close")
     signs = {
         -- icons / text used for a diagnostic
         error = "",

--- a/lua/trouble/folds.lua
+++ b/lua/trouble/folds.lua
@@ -1,8 +1,13 @@
+local config = require("trouble.config")
+
 local M = {}
 
 M.folded = {}
 
-function M.is_folded(filename) return M.folded[filename] == true end
+function M.is_folded(filename)
+    local fold = M.folded[filename]
+    return (fold == nil and config.options.default_fold == "close") or (fold == true)
+end
 
 function M.toggle(filename) M.folded[filename] = not M.is_folded(filename) end
 

--- a/lua/trouble/folds.lua
+++ b/lua/trouble/folds.lua
@@ -6,7 +6,7 @@ M.folded = {}
 
 function M.is_folded(filename)
     local fold = M.folded[filename]
-    return (fold == nil and config.options.default_fold == "close") or (fold == true)
+    return (fold == nil and config.options.auto_fold == true) or (fold == true)
 end
 
 function M.toggle(filename) M.folded[filename] = not M.is_folded(filename) end


### PR DESCRIPTION
This PR implements a `default_fold` option: a state at which file's trouble list appears when newly created.

Implementation seems a bit hacky. It relies on an implicit assumption that file's diagnostics is newly created if there is no record of it inside `trouble.folds.folded`. Please, feel free to rewrite it if there is a better way.